### PR TITLE
Add new functionalities to compute S/B ratio

### DIFF
--- a/Training/Macros/calSnB.C
+++ b/Training/Macros/calSnB.C
@@ -4,59 +4,7 @@
 #include <string>
 #include <vector>
 
-std::string floatInStrToStr(std::string str)
-{
-  for (auto pos = str.find(".", 0); pos != std::string::npos; ) {
-    str.replace(pos, 1, "p");
-    pos = str.find(".", pos+1);
-  }
-  return str;
-}
-
-std::string runSkimMass(const float pTMin, const float pTMax, const char* dataset,
-    const std::vector<std::string>& dataFiles,
-    const std::vector<std::string>& mcFiles,
-    const std::string commonCuts, const std::string specialCuts
-    )
-{
-  const std::string ptCuts =
-      Form("cand_pT > %.1f&& cand_pT < %.1f", pTMin, pTMax);
-  const std::string ptStr = floatInStrToStr(
-      Form("pT%.1f_%.1f_y1p0", pTMin, pTMax));
-  // data
-  {
-    const std::string histName = 
-      Form("cand_mass_%s_%s", dataset, ptStr.c_str());
-    const std::string histTitle = Form("%s pT %.1f to %.1f GeV;"
-        "M_{K_{S}^{0}p} (GeV);Events per bin", dataset, pTMin, pTMax);
-    const std::string outputFileName =
-      "output_" + histName + ".root";
-    const bool isMC = false;
-
-    Pars pars(dataFiles, commonCuts, ptCuts, specialCuts,
-        histName, histTitle, outputFileName, isMC);
-
-    skimMass(pars);
-  }
-
-  // MC
-  {
-    const std::string histName = 
-      Form("cand_mass_MC_%s_%s", dataset, ptStr.c_str());
-    const std::string histTitle = Form("MB pT %.1f to %.1f GeV;"
-        "M_{K_{S}^{0}p} (GeV);Events per bin", pTMin, pTMax);
-    const std::string outputFileName = "output_" + histName + ".root";
-    const bool isMC = true;
-
-    Pars pars(mcFiles, commonCuts, ptCuts, specialCuts,
-        histName, histTitle, outputFileName, isMC);
-
-    skimMass(pars);
-  }
-  return ptStr;
-}
-
-void calSnB()
+void calSnBFromNTuple()
 {
   // common cuts
   const float dlSig3DKs = 5.0;
@@ -69,7 +17,7 @@ void calSnB()
         "&& cos(cand_dau0_dca) > %f ",
         dlSig3DKs, cosAngle3DKs, dcaKs);
 
-  // datasets for pT > 6
+  // datasets for pT > 6 || pT>4
   std::vector<std::string> data6to20 = {
         "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB1_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
         "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB2_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
@@ -89,12 +37,13 @@ void calSnB()
     };
 
   std::vector<std::string> MC5p9 = {
+    "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/MC_pPb_pT5p9_lambdacAna_mc_AllEntries_pT0p9to20p0_yAbs1p0_absMassDiff20p000_LamCKsP.root",
     "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/MC_pPb_pT5p9_lambdacAna_mc_AllEntries_pT0p9to20p0_yAbs1p0_absMassDiff20p000_LamCKsP.root"
   };
 
   const std::string specialCuts = "true";
 
-  const std::vector<float> pTs {6.0, 8.0, 10.0};
+  const std::vector<float> pTs {4.0, 6.0, 8.0, 10.0};
   // 0 signal, 1 background, 2, eff_S, 3, eff_B
   std::vector<std::vector<double>> yields;
 
@@ -103,8 +52,8 @@ void calSnB()
     const float pTMax = pTs.at(ipt);
     auto ptStr = runSkimMass(pTMin, pTMax, "MB",
         data6to20, MC5p9, commonCuts, specialCuts);
-    TFile data(Form("output_cand_mass_MB_%s.root", ptStr.c_str()));
-    TFile mc(Form("output_cand_mass_MC_MB_%s.root", ptStr.c_str()));
+    TFile data(Form("StoB/output_cand_mass_MB_%s.root", ptStr.c_str()));
+    TFile mc(Form("StoB/output_cand_mass_MC_MB_%s.root", ptStr.c_str()));
     TH1D* hMass;
     TH1D* hMassMC;
     data.GetObject(Form("cand_mass_MB_%s", ptStr.c_str()), hMass);
@@ -151,5 +100,90 @@ void calSnB()
     std::cout << "Before cuts" << std::endl;
     std::cout << "S: " << sPrime << std::endl;
     std::cout << "B: " << bPrime << std::endl;
+  }
+}
+
+void calSnBFromHist()
+{
+  std::map<std::string, std::map<std::string, std::string>> inputs;
+  std::map<std::string, std::vector<float>> pTVecs;
+
+  inputs["MB"]["data"] = "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB_CutBase.root";
+  inputs["MB"]["MC"] = "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/MC_pPb_lambdacAna_mc_AllEntries_LamCKsP_Cutbase.root";
+  pTVecs["MB"] = {2.0, 3.0, 4.0};
+
+  inputs["HM"]["data"] = "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataHM_CutBase.root";
+  inputs["HM"]["MC"] = "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/MC_pPb_lambdacAna_mc_AllEntries_LamCKsP_Cutbase.root";
+  pTVecs["HM"] = {2.0, 3.0, 4.0, 6.0, 8.0, 10.0};
+  // 0 signal, 1 background, 2, eff_S, 3, eff_B
+  std::vector<std::vector<double>> yields;
+
+  for (const auto e : inputs) {
+    const auto label = e.first.c_str();
+    const auto dataFile = e.second.at("data");
+    const auto mcFile = e.second.at("MC");
+    const auto& pTs = pTVecs.at(label);
+
+    //cout << label << endl;
+
+    for (size_t ipt=1; ipt < pTs.size() ; ++ipt) {
+      //cout << "ipt: " << ipt<< endl;
+      const float pTMin = pTs.at(ipt-1);
+      const float pTMax = pTs.at(ipt);
+      const std::string ptStr = floatInStrToStr(
+          Form("pT%.1f_%.1f_y1p0", pTMin, pTMax));
+      skimMass(dataFile.c_str(), mcFile.c_str(),
+          pTMin, pTMax, 
+          Form("cand_mass_%s_%s", label, ptStr.c_str()), label);
+      TFile data(Form("StoB/output_cand_mass_%s_%s.root", label, ptStr.c_str()));
+      TFile mc(Form("StoB/output_cand_mass_MC_%s_%s.root", label, ptStr.c_str()));
+      TH1D* hMass;
+      TH1D* hMassMC;
+      data.GetObject(Form("cand_mass_%s_%s", label, ptStr.c_str()), hMass);
+      mc.GetObject(Form("cand_mass_MC_%s_%s", label, ptStr.c_str()), hMassMC);
+
+      auto ret = simpleFit(hMass, hMassMC, pTMin, pTMax);
+
+      TTree* tData; TTree* tMC;
+      data.GetObject("counts", tData);
+      mc.GetObject("counts", tMC);
+      double effS, effB;
+      tData->SetBranchAddress("eff", &effB);
+      tMC->SetBranchAddress("eff", &effS);
+      tData->GetEntry(0);
+      tMC->GetEntry(0);
+
+      ret.push_back(effS);
+      ret.push_back(effB);
+
+      yields.push_back(ret);
+    }
+
+    std::cout << std::endl;
+    std::cout << "==============================" << std::endl;
+    std::cout << "Summary for " << label << std::endl;
+    for (size_t ipt=1; ipt < pTs.size() ; ++ipt) {
+      const float pTMin = pTs.at(ipt-1);
+      const float pTMax = pTs.at(ipt);
+
+      const auto ret = yields.at(ipt-1);
+
+      const double EffS = ret.at(2);
+      const double EffB = ret.at(3);
+      const double S = ret.at(0);
+      const double B = ret.at(1);
+      const double sPrime = S/EffS;
+      const double bPrime = B/EffB;
+
+      std::cout << "MB: " << pTMin << " " << pTMax << std::endl;
+      std::cout << "After cuts" << std::endl;
+      std::cout << "EffS: " << EffS << std::endl;
+      std::cout << "EffB: " << EffB << std::endl;
+      std::cout << "S: " << S << std::endl;
+      std::cout << "B: " << B << std::endl;
+      std::cout << "Before cuts" << std::endl;
+      std::cout << "S: " << sPrime << std::endl;
+      std::cout << "B: " << bPrime << std::endl;
+    }
   }
 }

--- a/Training/Macros/calSnB.C
+++ b/Training/Macros/calSnB.C
@@ -1,0 +1,155 @@
+#include "skimMass.C"
+#include "fitHist.C"
+#include "TString.h"
+#include <string>
+#include <vector>
+
+std::string floatInStrToStr(std::string str)
+{
+  for (auto pos = str.find(".", 0); pos != std::string::npos; ) {
+    str.replace(pos, 1, "p");
+    pos = str.find(".", pos+1);
+  }
+  return str;
+}
+
+std::string runSkimMass(const float pTMin, const float pTMax, const char* dataset,
+    const std::vector<std::string>& dataFiles,
+    const std::vector<std::string>& mcFiles,
+    const std::string commonCuts, const std::string specialCuts
+    )
+{
+  const std::string ptCuts =
+      Form("cand_pT > %.1f&& cand_pT < %.1f", pTMin, pTMax);
+  const std::string ptStr = floatInStrToStr(
+      Form("pT%.1f_%.1f_y1p0", pTMin, pTMax));
+  // data
+  {
+    const std::string histName = 
+      Form("cand_mass_%s_%s", dataset, ptStr.c_str());
+    const std::string histTitle = Form("%s pT %.1f to %.1f GeV;"
+        "M_{K_{S}^{0}p} (GeV);Events per bin", dataset, pTMin, pTMax);
+    const std::string outputFileName =
+      "output_" + histName + ".root";
+    const bool isMC = false;
+
+    Pars pars(dataFiles, commonCuts, ptCuts, specialCuts,
+        histName, histTitle, outputFileName, isMC);
+
+    skimMass(pars);
+  }
+
+  // MC
+  {
+    const std::string histName = 
+      Form("cand_mass_MC_%s_%s", dataset, ptStr.c_str());
+    const std::string histTitle = Form("MB pT %.1f to %.1f GeV;"
+        "M_{K_{S}^{0}p} (GeV);Events per bin", pTMin, pTMax);
+    const std::string outputFileName = "output_" + histName + ".root";
+    const bool isMC = true;
+
+    Pars pars(mcFiles, commonCuts, ptCuts, specialCuts,
+        histName, histTitle, outputFileName, isMC);
+
+    skimMass(pars);
+  }
+  return ptStr;
+}
+
+void calSnB()
+{
+  // common cuts
+  const float dlSig3DKs = 5.0;
+  const float cosAngle3DKs = 0.999;
+  const float dcaKs = 0.5;
+
+  const std::string commonCuts = Form("abs(cand_y)<1 "
+        "&& cand_dau0_decayLength3D/cand_dau0_decayLengthError3D > %f "
+        "&& cos(cand_dau0_angle3D) > %f"
+        "&& cos(cand_dau0_dca) > %f ",
+        dlSig3DKs, cosAngle3DKs, dcaKs);
+
+  // datasets for pT > 6
+  std::vector<std::string> data6to20 = {
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB1_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB2_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB3_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB4_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB5_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB6_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB8_pPb_pT4p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP.root",
+
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB1_Pbp_pT6p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP_etaFlipped.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB3_Pbp_pT6p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP_etaFlipped.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB4_Pbp_pT6p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP_etaFlipped.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB5_Pbp_pT6p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP_etaFlipped.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB6_Pbp_pT6p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP_etaFlipped.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB7_Pbp_pT6p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP_etaFlipped.root",
+        "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/dataMB9_Pbp_pT6p0to20p0_yAbs1p0_absMassDiff0p150_LamCKsP_etaFlipped.root"
+    };
+
+  std::vector<std::string> MC5p9 = {
+    "root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/TrainPrep/MC_pPb_pT5p9_lambdacAna_mc_AllEntries_pT0p9to20p0_yAbs1p0_absMassDiff20p000_LamCKsP.root"
+  };
+
+  const std::string specialCuts = "true";
+
+  const std::vector<float> pTs {6.0, 8.0, 10.0};
+  // 0 signal, 1 background, 2, eff_S, 3, eff_B
+  std::vector<std::vector<double>> yields;
+
+  for (size_t ipt=1; ipt < pTs.size() ; ++ipt) {
+    const float pTMin = pTs.at(ipt-1);
+    const float pTMax = pTs.at(ipt);
+    auto ptStr = runSkimMass(pTMin, pTMax, "MB",
+        data6to20, MC5p9, commonCuts, specialCuts);
+    TFile data(Form("output_cand_mass_MB_%s.root", ptStr.c_str()));
+    TFile mc(Form("output_cand_mass_MC_MB_%s.root", ptStr.c_str()));
+    TH1D* hMass;
+    TH1D* hMassMC;
+    data.GetObject(Form("cand_mass_MB_%s", ptStr.c_str()), hMass);
+    mc.GetObject(Form("cand_mass_MC_MB_%s", ptStr.c_str()), hMassMC);
+    
+    auto ret = simpleFit(hMass, hMassMC, pTMin, pTMax);
+
+    TTree* tData; TTree* tMC;
+    data.GetObject("counts", tData);
+    mc.GetObject("counts", tMC);
+    double effS, effB;
+    tData->SetBranchAddress("eff", &effB);
+    tMC->SetBranchAddress("eff", &effS);
+    tData->GetEntry(0);
+    tMC->GetEntry(0);
+
+    ret.push_back(effS);
+    ret.push_back(effB);
+
+    yields.push_back(ret);
+  }
+
+  std::cout << "==============================" << std::endl;
+  std::cout << "Summary" << std::endl;
+  for (size_t ipt=1; ipt < pTs.size() ; ++ipt) {
+    const float pTMin = pTs.at(ipt-1);
+    const float pTMax = pTs.at(ipt);
+
+    const auto ret = yields.at(ipt-1);
+
+    const double EffS = ret.at(2);
+    const double EffB = ret.at(3);
+    const double S = ret.at(0);
+    const double B = ret.at(1);
+    const double sPrime = S/EffS;
+    const double bPrime = B/EffB;
+
+    std::cout << "MB: " << pTMin << " " << pTMax << std::endl;
+    std::cout << "After cuts" << std::endl;
+    std::cout << "EffS: " << EffS << std::endl;
+    std::cout << "EffB: " << EffB << std::endl;
+    std::cout << "S: " << S << std::endl;
+    std::cout << "B: " << B << std::endl;
+    std::cout << "Before cuts" << std::endl;
+    std::cout << "S: " << sPrime << std::endl;
+    std::cout << "B: " << bPrime << std::endl;
+  }
+}

--- a/Training/Macros/fitHist.C
+++ b/Training/Macros/fitHist.C
@@ -1,3 +1,5 @@
+#ifndef FIT_HIST
+#define FIT_HIST
 double bkgRejctPeak(double* x, double* pars)
 {
   if (x[0] > 2.2865-0.016 && x[0] < 2.2865+0.016) {
@@ -69,7 +71,8 @@ simpleFit(TH1* hMC, TH1* h, const double* bkgvars,
    c->Update();
    c->Draw();
    TString outputName = c->GetName();
-   c->Print(outputName+ "_cutbase.pdf");
+   //c->Print(outputName+ "_cutbase.pdf");
+   c->Print(Form("StoB/%s.pdf", h->GetName()));
 
    vector<double> output;
    std::copy(f->GetParameters(),
@@ -141,3 +144,4 @@ std::vector<double> simpleFit(TH1* hData, TH1* hMC,
 
   return yields;
 }
+#endif

--- a/Training/Macros/fitHist.C
+++ b/Training/Macros/fitHist.C
@@ -1,0 +1,143 @@
+double bkgRejctPeak(double* x, double* pars)
+{
+  if (x[0] > 2.2865-0.016 && x[0] < 2.2865+0.016) {
+    TF1::RejectPoint();
+    return 0;
+  }
+  ROOT::Math::ChebyshevPol chebyshev(3);
+  return chebyshev(x, pars);
+}
+
+std::vector<double>
+simpleFit(TH1* hMC, TH1* h, const double* bkgvars,
+               const double lw, const double up, TCanvas* c)
+{
+  TF1 fMC("fMC", "[0]*([1] * TMath::Gaus(x, [2], [3]*(1+[5]), true) + (1-[1]) * TMath::Gaus(x, [2], [4]*(1+[5]), true))");
+  fMC.SetParameter(0, 100);
+  fMC.SetParameter(1, 0.5);
+  fMC.SetParLimits(1, 0, 1);
+  fMC.SetParameter(2, 2.2865);
+  fMC.SetParameter(3, 0.005);
+  fMC.SetParameter(4, 0.01);
+  fMC.FixParameter(5, 0);
+  //hMC->Fit(&fMC, "RN", "", 2.24, 2.32);
+  //hMC->Fit(&fMC, "RN", "", 2.24, 2.32);
+  hMC->Fit(&fMC, "RN", "", 2.2, 2.38);
+  hMC->Fit(&fMC, "RN", "", 2.2, 2.38);
+  //gROOT->ForceStyle();
+  gStyle->SetOptFit(1111);
+  ROOT::Math::ChebyshevPol chebyshev(3);
+  auto fbkgReject = make_shared<TF1>
+    ("fbkgReject", bkgRejctPeak, lw, up, 4);
+  auto fbkg = make_shared<TF1>("fbkg", &chebyshev, lw, up, 4);
+
+  auto f = make_shared<TF1>("f", "fMC + cheb3(6)", lw, up);
+
+  fbkgReject->SetParameters(bkgvars);
+  h->Fit(fbkgReject.get(), "R", "", lw, up);
+  h->Fit(fbkgReject.get(), "MR", "", lw, up);
+
+  for (int i=0; i<fbkgReject->GetNpar(); ++i) {
+    fbkg->SetParameter(i, fbkgReject->GetParameter(i));
+    f->FixParameter(i+6, fbkgReject->GetParameter(i));
+  }
+
+   for (int i=0; i != 5; ++i) {
+     f->SetParameter(i, fMC.GetParameter(i));
+   }
+   f->FixParameter(1, fMC.GetParameter(1));
+   f->FixParameter(3, fMC.GetParameter(3));
+   f->FixParameter(4, fMC.GetParameter(4));
+   f->SetParameter(5, 0);
+   f->SetParLimits(5, -1, 1);
+   h->Fit(f.get(), "R", "", lw, up);
+   h->Fit(f.get(), "R", "", lw, up);
+
+   h->Fit(f.get(), "RM", "", lw, up);
+   h->Fit(f.get(), "RME", "", lw, up);
+
+   h->Draw("E");
+
+   c->Draw();
+
+   c->cd();
+   f->Draw("SAME");
+   fbkg->SetLineColor(kBlue);
+   fbkg->SetLineStyle(2);
+   fbkg->Draw("SAME");
+   c->Modified();
+   c->Update();
+   c->Draw();
+   TString outputName = c->GetName();
+   c->Print(outputName+ "_cutbase.pdf");
+
+   vector<double> output;
+   std::copy(f->GetParameters(),
+             f->GetParameters()+f->GetNpar(),
+             std::back_inserter(output));
+   std::copy(f->GetParErrors(),
+             f->GetParErrors()+f->GetNpar(),
+             std::back_inserter(output));
+   return output;
+}
+
+std::vector<double> simpleFit(TH1* hData, TH1* hMC,
+    const double pTMin, const double pTMax)
+{
+  gStyle->SetOptStat(0);
+  //gStyle->SetPadTickX(1);
+  //gStyle->SetPadTickY(1);
+
+  TString output = Form("mass_pT%.1fto%.1f", pTMin, pTMax);
+  for (auto pos = output.Index("."); pos>=0; ) {
+    output.Replace(pos, 1, "p");
+    pos = output.Index(".");
+  }
+  TCanvas c(output.Data(), "", 600, 450);
+  c.SetTopMargin(0.07);
+  c.SetLeftMargin(0.13);
+  c.SetBottomMargin(0.14);
+  c.SetRightMargin(0.03);
+
+  TGaxis::SetMaxDigits(5);
+  TGaxis::SetExponentOffset(-0.05);
+
+  hData->SetTitle(Form(";M_{pK^{0}_{s}} (GeV);Events / %.1f MeV", 1000*hData->GetBinWidth(1)));
+  hData->GetXaxis()->SetTitleSize(0.042);
+  hData->GetYaxis()->SetTitleSize(0.042);
+  hData->GetXaxis()->SetTitleOffset(1.2);
+  hData->GetXaxis()->CenterTitle();
+  hData->GetYaxis()->CenterTitle();
+  hData->SetMarkerStyle(20);
+  hData->SetMarkerSize(1.0);
+  hData->SetLineColor(kBlack);
+  hData->GetXaxis()->SetRangeUser(2.18, 2.4);
+  //hData->SetMaximum(hData->GetMaximum() * 1.05);
+
+  const double pars[] = {4000, -500, 200, 10};
+  simpleFit(hMC, hData, pars, 2.18, 2.4, &c);
+
+  auto f = (TF1*)hData->GetListOfFunctions()->FindObject("f")->Clone("fTotal");
+  hData->GetListOfFunctions()->FindObject("f")->Delete();
+  TF1 fbkg ("fbkg", "cheb3", 2.18, 2.4);
+  fbkg.SetParameter(0, f->GetParameter(6));
+  fbkg.SetParameter(1, f->GetParameter(7));
+  fbkg.SetParameter(2, f->GetParameter(8));
+  fbkg.SetParameter(3, f->GetParameter(9));
+
+  const auto frac1 = f->GetParameter(1);
+  const auto sigma1 = f->GetParameter(3);
+  const auto sigma2 = f->GetParameter(4);
+  const auto sigma = sqrt(frac1 * sigma1 * sigma1 + (1-frac1) * sigma2 * sigma2);
+  const auto yieldsBkg = fbkg.Integral(2.2865-sigma*2.6, 2.2865+sigma*2.6)/ hData->GetBinWidth(1);
+  const auto yieldsSignal = f->GetParameter(0)/ hData->GetBinWidth(1);
+  std::cout << "After special cuts" << std::endl;
+  std::cout << "Signal: " << yieldsSignal << std::endl;
+  std::cout << "Background: " << yieldsBkg << std::endl;
+
+  std::vector<double> yields;
+  yields.push_back(yieldsSignal);
+  yields.push_back(yieldsBkg);
+
+  return yields;
+}

--- a/Training/Macros/skimMass.C
+++ b/Training/Macros/skimMass.C
@@ -1,21 +1,38 @@
 #include <string>
 #include <vector>
 #include "TROOT.h"
+#include "TTree.h"
 #include "ROOT/RDataFrame.hxx"
-#include "TParameter.h"
-
-#pragma link C++ class TParameter<unsigned long long>+;
 
 using namespace ROOT;
+
 struct Pars
 {
   std::vector<std::string> fileNames;
-  std::string cuts;
+  std::string commonCuts;
+  std::string ptCuts;
+  std::string specialCuts;
   std::string histName;
   std::string histTitle;
   std::string outputFileName;
   bool isMC;
+
+  Pars() {};
+  Pars(const std::vector<std::string> fileNames_,
+      const std::string commonCuts_,
+      const std::string ptCuts_,
+      const std::string specialCuts_,
+      const std::string histName_,
+      const std::string histTitle_,
+      const std::string outputFileName_,
+      const bool isMC_
+      )
+    : fileNames(fileNames_), commonCuts(commonCuts_),
+    ptCuts(ptCuts_), specialCuts(specialCuts_),
+    histName(histName_), histTitle(histTitle_),
+    outputFileName(outputFileName_), isMC(isMC_) {}
 };
+
 
 void skimMass(Pars pars)
 {
@@ -23,31 +40,45 @@ void skimMass(Pars pars)
   const std::string treeName = pars.isMC ?
     "lambdacAna_mc/ParticleNTuple" : "lambdacAna/ParticleNTuple";
   const auto& fileNames = pars.fileNames;
-  auto df = RDataFrame(treeName, fileNames);
+  auto dfInput = RDataFrame(treeName, fileNames);
 
-  const auto& cuts = pars.cuts;
+  const auto commonCuts = pars.commonCuts;
+  const auto ptCuts = pars.ptCuts;
+  auto df = dfInput.Filter(commonCuts).Filter(ptCuts);
 
   auto dfInitial = pars.isMC ? df.Filter("abs(cand_mass-2.2865)<0.3")
     :df.Filter("abs(cand_mass-2.2865)>0.06"
             " && abs(cand_mass-2.2865)>0.11");
 
-  auto dfSkim = df.Filter(cuts);
-  auto dfPass = dfInitial.Filter(cuts);
+  const auto specialCuts = pars.specialCuts;
+  auto dfSkim = df.Filter(specialCuts);
+
+  auto dfPass = dfInitial.Filter(specialCuts);
 
   auto total = dfInitial.Count();
   auto pass = dfPass.Count();
 
   const char* histName = pars.histName.c_str();
   const char* histTitle = pars.histTitle.c_str();
-  auto hMass = dfSkim.Histo1D({histName, histTitle, 120, 2.15, 2.45});
+  auto hMass = dfSkim.Histo1D({histName, histTitle, 120, 2.15, 2.45}, "cand_mass");
 
   const char* outputFileName = pars.outputFileName.c_str();
+  auto total_val = total.GetValue();
+  auto pass_val = pass.GetValue();
+
+  std::cout << pars.histName << std::endl;
+  std::cout << "Total counts: " << total_val << std::endl;
+  std::cout << "Passed counts: " << pass_val << std::endl;
+
+  TTree t("counts", "counts");
+  t.Branch("total", &total_val);
+  t.Branch("pass", &pass_val);
+
+  double eff = static_cast<double>(pass_val)/static_cast<double>(total_val);
+  t.Branch("eff", &eff);
+  t.Fill();
+
   TFile ofile(outputFileName, "RECREATE");
   hMass->Write();
-  const auto total_val = total.GetValue();
-  const auto pass_val = pass.GetValue();
-  TParameter<unsigned long long> total_par("total", total_val);
-  TParameter pass_par("pass", pass_val);
-  total_par.Write();
-  pass_par.Write();
+  t.Write();
 }

--- a/Training/Macros/skimMass.C
+++ b/Training/Macros/skimMass.C
@@ -4,6 +4,13 @@
 #include "TTree.h"
 #include "ROOT/RDataFrame.hxx"
 
+#ifndef FIT_HIST
+#include "fitHist.C"
+#endif
+
+#ifndef SKIM_MASS
+#define SKIM_MASS
+
 using namespace ROOT;
 
 struct Pars
@@ -82,3 +89,191 @@ void skimMass(Pars pars)
   hMass->Write();
   t.Write();
 }
+
+std::string floatInStrToStr(std::string str)
+{
+  for (auto pos = str.find(".", 0); pos != std::string::npos; ) {
+    str.replace(pos, 1, "p");
+    pos = str.find(".", pos+1);
+  }
+  return str;
+}
+
+std::string runSkimMass(const float pTMin, const float pTMax, const char* dataset,
+    const std::vector<std::string>& dataFiles,
+    const std::vector<std::string>& mcFiles,
+    const std::string commonCuts, const std::string specialCuts
+    )
+{
+  const std::string ptCuts =
+      Form("cand_pT > %.1f&& cand_pT < %.1f", pTMin, pTMax);
+  const std::string ptStr = floatInStrToStr(
+      Form("pT%.1f_%.1f_y1p0", pTMin, pTMax));
+  // data
+  {
+    const std::string histName = 
+      Form("cand_mass_%s_%s", dataset, ptStr.c_str());
+    const std::string histTitle = Form("%s pT %.1f to %.1f GeV;"
+        "M_{K_{S}^{0}p} (GeV);Events per bin", dataset, pTMin, pTMax);
+    const std::string outputFileName =
+      "StoB/output_" + histName + ".root";
+    const bool isMC = false;
+
+    Pars pars(dataFiles, commonCuts, ptCuts, specialCuts,
+        histName, histTitle, outputFileName, isMC);
+
+    skimMass(pars);
+  }
+
+  // MC
+  {
+    const std::string histName = 
+      Form("cand_mass_MC_%s_%s", dataset, ptStr.c_str());
+    const std::string histTitle = Form("MB pT %.1f to %.1f GeV;"
+        "M_{K_{S}^{0}p} (GeV);Events per bin", pTMin, pTMax);
+    const std::string outputFileName = "StoB/output_" + histName + ".root";
+    const bool isMC = true;
+
+    Pars pars(mcFiles, commonCuts, ptCuts, specialCuts,
+        histName, histTitle, outputFileName, isMC);
+
+    skimMass(pars);
+  }
+  return ptStr;
+}
+
+
+void skimMass(const char* inData, const char* inMC,
+    const double pTMin, const double pTMax,
+    const char* histName, const char* label)
+{
+  TFile* dataFile = TFile::Open(inData);
+  TFile* MCFile = TFile::Open(inMC);
+  TH3D *hData3D, *hMC3D, *hData3DNoCut, *hMC3DNoCut;
+  dataFile->GetObject("lambdacAna/hMassPtY;1", hData3D);
+  MCFile->GetObject("lambdacAna_mc/hMassPtY;1", hMC3D);
+  dataFile->GetObject("lambdacAna/hMassPtYNoCut;1", hData3DNoCut);
+  MCFile->GetObject("lambdacAna_mc/hMassPtYNoCut;1", hMC3DNoCut);
+
+  const auto pTBinMin = hData3D->GetYaxis()->FindBin(pTMin);
+  const auto pTBinMax = hData3D->GetYaxis()->FindBin(pTMax) - 1;
+
+  const auto yBinMin = hData3D->GetZaxis()->FindBin(-1.);
+  const auto yBinMax = hData3D->GetZaxis()->FindBin(1.) - 1;
+
+  auto hData = hData3D->ProjectionX(histName,
+             pTBinMin, pTBinMax, yBinMin, yBinMax);
+  hData->SetTitle( Form("%s pT %.1f to %.1f", label, pTMin, pTMax) );
+
+  auto hDataNoCut = hData3DNoCut->ProjectionX(Form("%s_NoCut", histName),
+             pTBinMin, pTBinMax, yBinMin, yBinMax);
+  hDataNoCut->SetTitle(
+      Form("NoCut %s pT %.1f to %.1f", label, pTMin, pTMax) );
+
+  TString MCName(histName);
+  MCName.Replace(0, 9, "cand_mass_MC");
+  auto hMC = hMC3D->ProjectionX(MCName,
+                pTBinMin, pTBinMax, 6, 15);
+  hMC->SetTitle(Form("MC %s %.1fto%.1f", label, pTMin, pTMax));
+
+  auto hMCNoCut = hMC3DNoCut->ProjectionX(MCName+"_NoCut",
+                pTBinMin, pTBinMax, 6, 15);
+  hMCNoCut->SetTitle(Form("MC NoCut %s %.1fto%.1f", label, pTMin, pTMax));
+
+  // fit for w/o cuts is not stable
+  /*
+  const double lw = 2.176;
+  const double up = 2.42;
+  const double bkgvars[] = {40000., -500, 50, 50};
+
+  auto fbkgReject = make_shared<TF1>
+    ("fbkgReject", bkgRejctPeak, lw, up, 4);
+  auto fbkgRejectNoCut = make_shared<TF1>
+    ("fbkgRejectNoCut", bkgRejctPeak, lw, up, 4);
+
+  TCanvas c("c", "", 600*2, 480);
+  c.Divide(2, 1);
+
+  c.cd(1);
+  fbkgReject->SetParameters(bkgvars);
+  hData->Fit(fbkgReject.get(), "QRN", "", lw, up);
+  hData->Fit(fbkgReject.get(), "MRN", "", lw, up);
+  hData->Draw("E");
+
+  c.cd(2);
+  fbkgRejectNoCut->SetParameters(bkgvars);
+  hDataNoCut->Fit(fbkgRejectNoCut.get(), "QRN", "", lw, up);
+  hDataNoCut->Fit(fbkgRejectNoCut.get(), "MRN", "", lw, up);
+  hDataNoCut->Draw("E");
+
+  ROOT::Math::ChebyshevPol chebyshev(3);
+  auto fbkg = make_shared<TF1>("fbkg", &chebyshev, lw, up, 4);
+  auto fbkgNoCut = make_shared<TF1>("fbkgNoCut", &chebyshev, lw, up, 4);
+  fbkg->SetParameters(fbkgReject->GetParameters());
+  fbkgNoCut->SetParameters(fbkgRejectNoCut->GetParameters());
+  c.cd(1);
+  fbkg->Draw("SAME");
+  c.cd(2);
+  fbkgNoCut->Draw("SAME");
+
+  TString pdfFileName = TString(histName) + "_sideband.pdf";
+
+  c.Print(pdfFileName);
+  */
+
+  TString outputFileName = "StoB/output_" + TString(histName) + ".root";
+  TString outputFileNameMC = "StoB/output_" + MCName + ".root";
+
+  double eff = 0;
+
+  /*
+  const double cand_mass = 2.2865;
+  double left = fbkg->Integral(cand_mass-0.11, cand_mass-0.6);
+  double leftNoCut = fbkgNoCut->Integral(cand_mass-0.11, cand_mass-0.6);
+  double right = fbkg->Integral(cand_mass+0.06, cand_mass+0.11);
+  double rightNoCut = fbkgNoCut->Integral(cand_mass+0.06, cand_mass+0.11);
+  eff = (left+right) / (leftNoCut + rightNoCut);
+  */
+
+  {
+    const double cand_mass = 2.2865;
+    const auto leftBinMin = hDataNoCut->FindBin(cand_mass - 0.11);
+    const auto leftBinMax = hDataNoCut->FindBin(cand_mass - 0.06);
+    const auto rightBinMin = hDataNoCut->FindBin(cand_mass + 0.06);
+    const auto rightBinMax = hDataNoCut->FindBin(cand_mass + 0.11);
+    double left = hData->Integral(leftBinMin, leftBinMax);
+    double leftNoCut = hDataNoCut->Integral(leftBinMin, leftBinMax);
+    double right = hData->Integral(rightBinMin, rightBinMax);
+    double rightNoCut = hDataNoCut->Integral(rightBinMin, rightBinMax);
+    eff = (left+right) / (leftNoCut + rightNoCut);
+  }
+
+  TTree* t, *tMC;
+  TFile ofile(outputFileName, "RECREATE");
+  t = new TTree("counts", "counts");
+  auto bEff = t->Branch("eff", &eff, "eff/D");
+  t->Fill();
+  hData->Write();
+  hDataNoCut->Write();
+  t->Write();
+  delete t;
+  ofile.Close();
+  cout << "Data done" << endl;
+
+  eff = hMC->Integral()/ hMCNoCut->Integral();
+  TFile ofileMC(outputFileNameMC, "RECREATE");
+  tMC = new TTree("counts", "counts");
+  tMC->Branch("eff", &eff);
+  tMC->Fill();
+  hMC->Write();
+  hMCNoCut->Write();
+  tMC->Write();
+  delete tMC;
+  ofileMC.Close();
+  cout << "MC done" << endl;
+
+  delete dataFile;
+  delete  MCFile;
+}
+
+#endif

--- a/Training/Macros/skimMass.C
+++ b/Training/Macros/skimMass.C
@@ -1,0 +1,53 @@
+#include <string>
+#include <vector>
+#include "TROOT.h"
+#include "ROOT/RDataFrame.hxx"
+#include "TParameter.h"
+
+#pragma link C++ class TParameter<unsigned long long>+;
+
+using namespace ROOT;
+struct Pars
+{
+  std::vector<std::string> fileNames;
+  std::string cuts;
+  std::string histName;
+  std::string histTitle;
+  std::string outputFileName;
+  bool isMC;
+};
+
+void skimMass(Pars pars)
+{
+  EnableImplicitMT();
+  const std::string treeName = pars.isMC ?
+    "lambdacAna_mc/ParticleNTuple" : "lambdacAna/ParticleNTuple";
+  const auto& fileNames = pars.fileNames;
+  auto df = RDataFrame(treeName, fileNames);
+
+  const auto& cuts = pars.cuts;
+
+  auto dfInitial = pars.isMC ? df.Filter("abs(cand_mass-2.2865)<0.3")
+    :df.Filter("abs(cand_mass-2.2865)>0.06"
+            " && abs(cand_mass-2.2865)>0.11");
+
+  auto dfSkim = df.Filter(cuts);
+  auto dfPass = dfInitial.Filter(cuts);
+
+  auto total = dfInitial.Count();
+  auto pass = dfPass.Count();
+
+  const char* histName = pars.histName.c_str();
+  const char* histTitle = pars.histTitle.c_str();
+  auto hMass = dfSkim.Histo1D({histName, histTitle, 120, 2.15, 2.45});
+
+  const char* outputFileName = pars.outputFileName.c_str();
+  TFile ofile(outputFileName, "RECREATE");
+  hMass->Write();
+  const auto total_val = total.GetValue();
+  const auto pass_val = pass.GetValue();
+  TParameter<unsigned long long> total_par("total", total_val);
+  TParameter pass_par("pass", pass_val);
+  total_par.Write();
+  pass_par.Write();
+}


### PR DESCRIPTION
Three new macros.
- `calSnB.C`, macros for calculating signal to background ratios. It calls `fitHist.C` and `skimMass.C`.
- `skimMass.C`, it provides functionality to produce histograms from input list of files containing `ParticleNTuple`. And the signal/background efficiency are also computed, saved in a `TTree` called `counts`.
- `fitHist.C` will produce fit the mass spectra using double Gaussian + 3rd Chebyshev.
Output files need to be saved under `./StoB/`.