### PR TITLE
add exit codes for protection

### DIFF
--- a/Training/scripts/appMVA/run_pT4to6_HM.sh
+++ b/Training/scripts/appMVA/run_pT4to6_HM.sh
@@ -143,7 +143,7 @@ _EOF_
 Exe="${OPENHF2020TOP}/Training/bin/TMVAClassificationApp"
 
 echo 'LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${OPENHF2020TOP}/Utilities/lib' "${Exe}" run.xml
-ROOT_INCLUDE_PATH=${ROOT_INCLUDE_PATH}:${OPENHF2020TOP}/Utilities LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${OPENHF2020TOP}/Utilities/lib ${Exe} run.xml
+ROOT_INCLUDE_PATH=${ROOT_INCLUDE_PATH}:${OPENHF2020TOP}/Utilities LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${OPENHF2020TOP}/Utilities/lib ${Exe} run.xml || exit $?
 
 ls -lsth
 InputSample="${2}"

--- a/Training/src/TMVAClassificationApp.cc
+++ b/Training/src/TMVAClassificationApp.cc
@@ -420,6 +420,13 @@ int TMVAClassificationApp(const tmvaConfigs& configs)
   for (Long64_t ientry=0; ientry<nentries; ientry++) {
     if (ientry % 20000 == 0) cout << "pass " << ientry << endl;
     auto jentry =  p.LoadTree(ientry);
+    if (jentry == -3) {
+      outputFile.Write();
+      outputFileWS.Write();
+      delete reader;
+      delete pp;
+      return -3;
+    }
     if (jentry < 0) break;
     p.GetEntry(ientry);
 


### PR DESCRIPTION
Now exit code -3 (or 253 after converting to unsigned char) will be returned if remote `TFile` cannot be opened properly. And script for selecting failed condor job will be added in the future. That script should pick out the failed jobs exit with code -3 or 253.