### PR TITLE
Add workaround to protect tree reading process

### DIFF
--- a/Training/scripts/appMVA/writeSub.py
+++ b/Training/scripts/appMVA/writeSub.py
@@ -80,6 +80,6 @@ with open("sub_%s_%s_%s.jdl" % (args.dataset, args.boost, myexe.replace(".sh", "
     f.write(cmd)
     f.close
     subprocess.run(['mkdir', logdir])
-    print("log dir is ", logdir)
+    print("log dir is", logdir)
     #subprocess.run(['condor_submit', f.name])
     #print (f.name)

--- a/Training/scripts/appMVA/writeSub.py
+++ b/Training/scripts/appMVA/writeSub.py
@@ -51,6 +51,9 @@ should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 transfer_output_files = ""
 #+JobFlavour = "workday"
+on_exit_remove          = (ExitBySignal == False) && (ExitCode == 0)
+max_retries             = 3
+requirements = Machine =!= LastRemoteHost
 ''' % (os.path.basename(args.inputCert), proxy_path, args.userexe, logdir, logdir ,logdir)
 
 num = 0

--- a/Training/src/TMVAClassificationApp.cc
+++ b/Training/src/TMVAClassificationApp.cc
@@ -107,6 +107,7 @@ int main( int argc, char** argv )
     configs.setOutFileName("TMVA_" + tempOutFileName);
   }
   int code = TMVAClassificationApp(configs);
+  cerr << "\nThe code for TMVAClassificationApp is " << code << endl;
   return code;
 }
 
@@ -427,11 +428,18 @@ int TMVAClassificationApp(const tmvaConfigs& configs)
       delete pp;
       return jentry;
     }
-    if (jentry < 0) break;
+    if (jentry < 0) {
+      cout << "Code for the last entry is " << ientry << endl;
+      break;
+    }
     auto bytes = p.GetEntry(ientry);
     if (bytes == 0) {
       std::cerr << "[ERROR] in TMVAClassificationApp: Cannot read "
                 << ientry << "th entry properly" << std::endl;
+      outputFile.Write();
+      outputFileWS.Write();
+      delete reader;
+      delete pp;
       return -2;
     }
 

--- a/Training/src/TMVAClassificationApp.cc
+++ b/Training/src/TMVAClassificationApp.cc
@@ -66,6 +66,7 @@ using std::vector;
 using std::ifstream;
 using std::getline;
 using std::cout;
+using std::cerr;
 using std::endl;
 using std::istringstream;
 using std::unique_ptr;

--- a/Training/src/TMVAClassificationApp.cc
+++ b/Training/src/TMVAClassificationApp.cc
@@ -420,15 +420,20 @@ int TMVAClassificationApp(const tmvaConfigs& configs)
   for (Long64_t ientry=0; ientry<nentries; ientry++) {
     if (ientry % 20000 == 0) cout << "pass " << ientry << endl;
     auto jentry =  p.LoadTree(ientry);
-    if (jentry == -3) {
+    if (jentry < 0 && jentry != -2) {
       outputFile.Write();
       outputFileWS.Write();
       delete reader;
       delete pp;
-      return -3;
+      return jentry;
     }
     if (jentry < 0) break;
-    p.GetEntry(ientry);
+    auto bytes = p.GetEntry(ientry);
+    if (bytes == 0) {
+      std::cerr << "[ERROR] in TMVAClassificationApp: Cannot read "
+                << ientry << "th entry properly" << std::endl;
+      return -2;
+    }
 
     // check trigger filter;
     if (!p.passHLT().at(triggerIndex)) continue;

--- a/prep.sh
+++ b/prep.sh
@@ -4,6 +4,12 @@ if [[ "${1}" = "-f" ]]; then
   echo "Force"
   Options=${1}
 fi
+
+if [[ "${1}" = "-fdev" ]]; then
+  echo "Force to create dev"
+  Options=${1}
+fi
+
 TargetDir=""
 if [[ -z ${2} ]]; then
   TargetDir="root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storage/Package"
@@ -13,6 +19,9 @@ fi
 TopDir=${PWD}
 git clone https://github.com/yszhang95/OpenHF2020.git
 cd $TopDir/OpenHF2020
+if [[ "${1}" = "-fdev" ]]; then
+    git checkout test
+fi
 source setup.sh
 cd Utilities
 make

--- a/prep.sh
+++ b/prep.sh
@@ -2,12 +2,12 @@
 Options=""
 if [[ "${1}" = "-f" ]]; then
   echo "Force"
-  Options=${1}
+  Options="-f"
 fi
 
 if [[ "${1}" = "-fdev" ]]; then
   echo "Force to create dev"
-  Options=${1}
+  Options="-f"
 fi
 
 TargetDir=""


### PR DESCRIPTION
I try to fix the issue #7.

I only allow the output of `LoadTree` to be -2 or positive to proceed. It is a strict way. But this still cannot capture the exit code and give a meaningful exit status for condor at all time. It is very hard to test and reproduce the issues on non-interactive nodes.