### PR TITLE
Abort as long as any error is detected

### DIFF
--- a/Training/include/functions.h
+++ b/Training/include/functions.h
@@ -122,6 +122,7 @@ public:
   bool                                        saveMatchedOnly() const;
   bool                                        flipEta() const;
   bool                                        selectDeDx() const;
+  bool                                        wantAbort() const;
 
 private:
   std::map<std::string, TString>              getMethod(const std::string&) const;
@@ -156,6 +157,7 @@ private:
   bool _saveMatchedOnly;
   bool _flipEta;
   bool _selectDeDx;
+  bool _wantAbort;
   bool _debug;
 };
 

--- a/Training/scripts/appMVA/run_pT4to6_HM.sh
+++ b/Training/scripts/appMVA/run_pT4to6_HM.sh
@@ -44,9 +44,9 @@ xrdcp root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storag
 
 pTLabel="4to6"
 
-Options="saveTree:selectMVA:saveDau:selectDeDx"
+Options="saveTree:selectMVA:saveDau:selectDeDx:wantAbort"
 if [[ $2 == *"Pbp"* ]]; then
-  Options="saveTree:selectMVA:saveDau:selectDeDx:flipEta"
+  Options="saveTree:selectMVA:saveDau:selectDeDx:wantAbort:flipEta"
 fi
 
 Trig=""

--- a/Training/src/TMVAClassificationApp.cc
+++ b/Training/src/TMVAClassificationApp.cc
@@ -128,6 +128,9 @@ int TMVAClassificationApp(const tmvaConfigs& configs)
   const bool flipEta = configs.flipEta();
   const bool selectDeDx = configs.selectDeDx();
   const bool pruneNTuple = configs.pruneNTuple();
+  const bool wantAbort = configs.wantAbort();
+
+  if (wantAbort) { gErrorAbortLevel = kError; }
 
   DeDxSelection dedxSel{0.7, 1.5, 0.75, 1.25};
 

--- a/Training/src/functions.cc
+++ b/Training/src/functions.cc
@@ -79,7 +79,7 @@ tmvaConfigs::tmvaConfigs(string inputXML, bool debug):
   _NtrkLow(0), _NtrkHigh(UShort_t(-1)),
   _saveTree(0), _saveDau(0), _selectMVA(0),
   _useEventWiseWeight(0), _isMC(0), _saveMatchedOnly(1),
-  _flipEta(0), _selectDeDx(0),  _debug(debug)
+  _flipEta(0), _selectDeDx(0), _wantAbort(0),  _debug(debug)
 {
   if (_debug) { cout << "\nStart readConfigs" << endl; }
 
@@ -208,6 +208,7 @@ tmvaConfigs::tmvaConfigs(string inputXML, bool debug):
     == options.end();
   _flipEta   = std::find(options.begin(), options.end(), "flipeta") != options.end();
   _selectDeDx = std::find(options.begin(), options.end(), "selectdedx") != options.end();
+  _wantAbort = std::find(options.begin(), options.end(), "wantabort") != options.end();
 
   if (_configs.count("signalFileList")
       && _configs.at("signalFileList").size())
@@ -828,6 +829,14 @@ bool tmvaConfigs::flipEta() const
 bool tmvaConfigs::selectDeDx() const
 {
   return _selectDeDx;
+}
+
+/**
+   Return if we want to abort when detecting kError
+ */
+bool tmvaConfigs::wantAbort() const
+{
+  return _wantAbort;
 }
 
 /**

--- a/Utilities/bin/manipJobs.pl
+++ b/Utilities/bin/manipJobs.pl
@@ -98,6 +98,21 @@ sub analyze {
         print "    ", $mycluster, "_", $_, ".log\n";
     }
     print "\n";
+    my @mylogs_removed = ();
+    foreach (@mylogs_filtered) {
+        my $matched_log = findErrors("$mylogdir/$_", "remove");
+        if ($matched_log) {
+            if ( $_ =~ /(.*)_(.*)\..+/ ) {
+                push(@mylogs_removed, $2);
+            }
+        }
+    }
+    print "  Jobs removed are:\n";
+    foreach (@mylogs_removed) {
+        print "    ", $mycluster, "_", $_, ".log\n";
+    }
+    print "\n";
+    push(@mylogs_buggy, @mylogs_removed);
 
     # get the filtered errs
     my @myerrs_filtered = filterNames(\@myerrs, $mycluster);
@@ -121,13 +136,14 @@ sub analyze {
     my (%hsh, @union_arr);
     @hsh{@mylogs_buggy, @myerrs_buggy} = ();
     @union_arr = keys %hsh;
+    @union_arr = sort @union_arr;
+
     print "  The unions of these jobs are:\n";
     foreach (@union_arr) {
         print "    ", $mycluster, "_", $_, "\n";
     }
     print "\nAnalyzed $mylog\n\n";
 
-    @union_arr = sort @union_arr;
     return @union_arr;
 }
 


### PR DESCRIPTION
Please check this [post](https://root-forum.cern.ch/t/how-to-detect-xrootd-error-and-protect-the-output/47695/10?u=y.s.zhang). A new option `wantAbort` as a workaround will abort the program as long as an error is detected. Never use this option unless run condor jobs.