### PR TITLE
Fix bugs in merge scripts and improve efficiency table implementation

### DIFF
--- a/Fit/MergeWS.py
+++ b/Fit/MergeWS.py
@@ -11,6 +11,9 @@ parser.add_argument('--outfile', dest='outfile', help='output file, not director
 parser.add_argument('--reweight', dest='reweight', help='weighted dataset', action='store_const', const=True)
 args = parser.parse_args()
 
+if args.reweight:
+  print(args.reweight)
+
 import ROOT
 ROOT.gSystem.Load("libRooFitCore.so")
 ROOT.gSystem.Load("libRooFit.so")
@@ -18,9 +21,10 @@ ROOT.gROOT.LoadMacro("MergeWS.cc+")
 conf = ROOT.Conf()
 conf._inFileList = args.inputList
 conf._wsName =  args.wsName
-conf._wsTitle = args.wsName if len(args.wsTitle) else args.wsTitle
+conf._wsTitle = args.wsName if not len(args.wsTitle) else args.wsTitle
 conf._dsName = args.dsName
-conf._dsTitle = args.dsName if len(args.dsTitle) else args.dsTitle
+conf._dsTitle = args.dsName if not len(args.dsTitle) else args.dsTitle
 conf._ofile = args.outfile
-conf._reweight = args.reweight
+conf._outDir = args.outdir
+conf._reweight = True if args.reweight else False
 ROOT.MergeWS(conf)

--- a/Training/include/functions.h
+++ b/Training/include/functions.h
@@ -123,6 +123,7 @@ public:
   bool                                        saveMatchedOnly() const;
   bool                                        flipEta() const;
   bool                                        selectDeDx() const;
+  bool                                        trigReweight() const;
   bool                                        wantAbort() const;
 
 private:
@@ -158,6 +159,7 @@ private:
   bool _saveMatchedOnly;
   bool _flipEta;
   bool _selectDeDx;
+  bool _trigReweight;
   bool _wantAbort;
   bool _debug;
 };

--- a/Training/scripts/appMVA/run_pT4to6_HM.sh
+++ b/Training/scripts/appMVA/run_pT4to6_HM.sh
@@ -44,9 +44,9 @@ xrdcp root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storag
 
 pTLabel="4to6"
 
-Options="saveTree:selectMVA:saveDau:selectDeDx:wantAbort"
+Options="saveTree:selectMVA:saveDau:selectDeDx:trigReweight:wantAbort"
 if [[ $2 == *"Pbp"* ]]; then
-  Options="saveTree:selectMVA:saveDau:selectDeDx:wantAbort:flipEta"
+  Options="saveTree:selectMVA:saveDau:selectDeDx:trigReweight:wantAbort:flipEta"
 fi
 
 Trig=""

--- a/Training/scripts/appMVA/run_pT4to6_MB.sh
+++ b/Training/scripts/appMVA/run_pT4to6_MB.sh
@@ -47,9 +47,9 @@ xrdcp root://eoscms.cern.ch///store/group/phys_heavyions/yousen/OpenHF2020Storag
 
 pTLabel="4to6"
 
-Options="saveTree:selectMVA:saveDau:selectDeDx:trigReweight:wantAbort"
+Options="saveTree:selectMVA:saveDau:selectDeDx:wantAbort"
 if [[ $2 == *"Pbp"* ]]; then
-  Options="saveTree:selectMVA:saveDau:selectDeDx:trigReweight:wantAbort:flipEta"
+  Options="saveTree:selectMVA:saveDau:selectDeDx:wantAbort:flipEta"
 fi
 
 Trig=""
@@ -85,23 +85,17 @@ cat > run.xml << _EOF_
     120, 2.15, 2.45, 10, 0., 10., 500, 0.0, 0.01
   </histoBinning>
   <trainXML>
-    MLP_vars3D_pT${pTLabel}_Np2N_noDR.xml
+    MLP_vars3D_pT${pTLabel}_MB_Np2N_noDR.xml
   </trainXML>
   <treeInfo>
     lambdacAna  ? 4122 ? -1
   </treeInfo>
   <methods>
-    MLP? MLP${pTLabel}Np2N_noDR? !H:!V:NeuronType=tanh:VarTransform=N,G:NCycles=200:HiddenLayers=N+2,N:TestRate=5:UseRegulator=True:ConvergenceTests=5:ConvergenceImprove=1E-3
+    MLP? MLP${pTLabel}MBNp2N_noDR? !H:!V:NeuronType=tanh:VarTransform=N,G:NCycles=200:HiddenLayers=N+2,N:TestRate=5:UseRegulator=True:ConvergenceTests=5:ConvergenceImprove=1E-3
   </methods>
   <mvaCutMin>
     0.0005
   </mvaCutMin>
-  <NtrkRange>
-    185:250
-  </NtrkRange>
-  <effTable>
-    eff.root:Ntrk185:TGraphAsymmErrors
-  </effTable>
   <options>
     ${Options}
   </options>
@@ -132,7 +126,7 @@ cat > run.xml << _EOF_
     cand_angle3D:cand_dauCosOpenAngle3D:cand_Ntrkoffline
     cand_decayLength3D:cand_decayLengthError3D:
     Ntrkoffline:trigBit_2:trigBit_4:filterBit_4:filterBit_5:
-    MLP${pTLabel}Np2N_noDR:eventWeight
+    MLP${pTLabel}MBNp2N_noDR
   </KeptBranchNames>
   <RooWorkspace>
     ws${Trig}Pt${pTLabel}:ws${Trig}Pt${pTLabel}

--- a/Training/src/TMVAClassificationApp.cc
+++ b/Training/src/TMVAClassificationApp.cc
@@ -129,26 +129,30 @@ int TMVAClassificationApp(const tmvaConfigs& configs)
   const bool flipEta = configs.flipEta();
   const bool selectDeDx = configs.selectDeDx();
   const bool pruneNTuple = configs.pruneNTuple();
+  const bool reweightEvent = configs.trigReweight();
   const bool wantAbort = configs.wantAbort();
 
   if (wantAbort) { gErrorAbortLevel = kError; }
 
   DeDxSelection dedxSel{0.7, 1.5, 0.75, 1.25};
 
-  TFile effFile(configs.getEffFileName().c_str());
+  TFile* effFile;
+  if (reweightEvent) {
+    effFile = TFile::Open(configs.getEffFileName().c_str());
+  }
   TGraph* g(nullptr);
-  if (effFile.IsOpen()) {
+  if (effFile->IsOpen()) {
     if (configs.getEffGraphType() == "TGraphAsymmErrors") {
       const auto effname = configs.getEffGraphName();
-      g = (TGraphAsymmErrors*) effFile.Get(effname.c_str());
+      g = (TGraphAsymmErrors*) effFile->Get(effname.c_str());
     }
     else if (configs.getEffGraphType() == "TGraphErrors") {
       const auto effname = configs.getEffGraphName();
-      g = (TGraphErrors*) effFile.Get(effname.c_str());
+      g = (TGraphErrors*) effFile->Get(effname.c_str());
     }
+    effFile->Close();
   }
 
-  const bool reweightEvent = g;
   if (DEBUG) { cout << "Do reweighting: " << reweightEvent << endl;}
 
   EfficiencyTable<TGraph> effTab(g);

--- a/Training/src/TMVAClassificationApp.cc
+++ b/Training/src/TMVAClassificationApp.cc
@@ -137,20 +137,20 @@ int TMVAClassificationApp(const tmvaConfigs& configs)
   DeDxSelection dedxSel{0.7, 1.5, 0.75, 1.25};
 
   TFile* effFile;
+  TGraph* g(nullptr);
   if (reweightEvent) {
     effFile = TFile::Open(configs.getEffFileName().c_str());
-  }
-  TGraph* g(nullptr);
-  if (effFile->IsOpen()) {
-    if (configs.getEffGraphType() == "TGraphAsymmErrors") {
-      const auto effname = configs.getEffGraphName();
-      g = (TGraphAsymmErrors*) effFile->Get(effname.c_str());
+    if (effFile->IsOpen()) {
+      if (configs.getEffGraphType() == "TGraphAsymmErrors") {
+        const auto effname = configs.getEffGraphName();
+        g = (TGraphAsymmErrors*) effFile->Get(effname.c_str());
+      }
+      else if (configs.getEffGraphType() == "TGraphErrors") {
+        const auto effname = configs.getEffGraphName();
+        g = (TGraphErrors*) effFile->Get(effname.c_str());
+      }
+      effFile->Close();
     }
-    else if (configs.getEffGraphType() == "TGraphErrors") {
-      const auto effname = configs.getEffGraphName();
-      g = (TGraphErrors*) effFile->Get(effname.c_str());
-    }
-    effFile->Close();
   }
 
   if (DEBUG) { cout << "Do reweighting: " << reweightEvent << endl;}

--- a/Training/src/functions.cc
+++ b/Training/src/functions.cc
@@ -209,6 +209,7 @@ tmvaConfigs::tmvaConfigs(string inputXML, bool debug):
     == options.end();
   _flipEta   = std::find(options.begin(), options.end(), "flipeta") != options.end();
   _selectDeDx = std::find(options.begin(), options.end(), "selectdedx") != options.end();
+  _trigReweight = std::find(options.begin(), options.end(), "trigreweight") != options.end();
   _wantAbort = std::find(options.begin(), options.end(), "wantabort") != options.end();
 
   if (_configs.count("signalFileList")
@@ -830,6 +831,13 @@ bool tmvaConfigs::flipEta() const
 bool tmvaConfigs::selectDeDx() const
 {
   return _selectDeDx;
+}
+
+/** Return if you want to reweight using trig efficiency
+ */
+bool tmvaConfigs::trigReweight() const
+{
+  return _trigReweight;
 }
 
 /**


### PR DESCRIPTION
- Sine I need retry for condor jobs, the old `perl` script will also capture the retry output. This gives lots of useless and misleading messages. Add a workaround in `perl` script, though not ideal.
- Fix the bug about weighting and naming for merging utilities
- Fix the bug for reading and writing related xrootd bug. Now pointers are used.
- Add an option to determine if I would like to reweight events using trigger efficiency table.